### PR TITLE
Fix import error in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-# -*- cfrom setuphelpers import *
+# -*- coding: utf-8 -*-
+from setuphelpers import *
 import os
 
 def install():


### PR DESCRIPTION
## Summary
- fix truncated file header that prevented importing `setuphelpers`

## Testing
- `python -m py_compile setup.py`


------
https://chatgpt.com/codex/tasks/task_e_68514ccab4b0832aacb9db19dd1d96c3